### PR TITLE
Add handling of escape characters

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,13 +1,15 @@
 import { tpl } from './tpl';
 import { fn } from './fn';
-
+import { cpesc } from 'esc';
 /**
  * compile mode, for higher performance
  * @param template
  * @param keys
  */
 export function compile(template: string, keys: string[]) {
-  const t = tpl(template);
+  const tp = cpesc(template);
+  
+  const t = tpl(tp);
   const r = fn(t, keys);
 
   /* return render function */

--- a/src/esc.ts
+++ b/src/esc.ts
@@ -1,0 +1,7 @@
+/**
+ * Will escape the character repeatedly to prevent it from being consumed
+ * @param template
+ */
+export function cpesc(template:string) {
+    return template.replaceAll(/\\/gi, "\\\\");
+}

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,16 +1,18 @@
 import { tpl } from './tpl';
 import { fn } from './fn';
-
+import { cpesc } from './esc';
 /**
  * template render entry
  * @param template
  * @param data
  */
 export function render(template: string, data: object): string {
+  const tp = cpesc(template)
+  
   const keys = Object.keys(data);
   const values = keys.map((k: any) => data[k]);
 
-  const t = tpl(template);
+  const t = tpl(tp);
   const f = fn(t, keys);
 
   return f(...values);


### PR DESCRIPTION
如果原字符串包含转义字符，在处理过程中会"消耗"掉。预处理将其double一下。